### PR TITLE
When using moodle brach master will be selected the latest DB

### DIFF
--- a/bin/wiris-moodle-docker-start
+++ b/bin/wiris-moodle-docker-start
@@ -47,10 +47,12 @@ fi
 
 # Prepare the database file to import from for a faster upgrade path.
 if [ -e "databases/${WIRIS_MOODLE_BRANCH}.sql" ]; then
-    WIRIS_MOODLE_IMPORTED_DB="databases/${WIRIS_MOODLE_BRANCH}.sql"
+    WIRIS_MOODLE_IMPORTED_DB="databases/${WIRIS_MOODLE_BRANCH}.sql" 
 else
-    WIRIS_MOODLE_IMPORTED_DB="databases/MOODLE_35_STABLE.sql"
+    WIRIS_MOODLE_IMPORTED_DB="databases/MOODLE_311_STABLE.sql"
 fi
+
+echo "=> Setting up Database ${WIRIS_MOODLE_IMPORTED_DB}"
 cp ${WIRIS_MOODLE_IMPORTED_DB} /tmp/database.sql
 
 # Step02. Validations on 'moodle' and 'moodle-docker'.


### PR DESCRIPTION
## Description

Modified bin/wiris-moodle-docker-start in order to select the latest version of the MOODLE_{ver}_STABLE.sql.

Added a bash command that will find all the files on the folder bin that start with 'MOODLE_', then they will be ordered by versions and, finally, it will get the file name from the last on the list. This command was based on this [stackoverflow post](https://stackoverflow.com/questions/69673995/bash-sorting-file-names-by-version)

## Steps to reproduce

1. Open the terminal on the project.
2. **Set WIRIS_MOODLE_BRANCH="master"** and use the group command **instal**l.
3. **Set MOODLE_DOCKER_PHP_VERSION** and use the group command **start**.
4. The selected DB will apear on the logs from the group command **start**.

---
