### PR TITLE
Multiple instances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,19 +1,27 @@
+# Changelog
 
-[Done]
+## Wiris Moodle Docker
 
-- Commands to compile and build a customized Moodle instance using docker.
-- Dependency management: download moodle-docker. 
-- Support for linux and OSx systems via bash commands.
+All notable changes to this project will be documented in this file.
 
-[Todo]
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-- Document README.md
-    - Quickstart
-    - How to test
-- Publish to github.
-- Decide which license to use.
+Last release of this project is 1.0.0 released on 6th of September 2021.
 
-[Feature-request]
+## [Unreleased]
 
-- Support to Windows systems via cmd file.
-- - Support to a PHP automated/build tool like [phing](https://www.phing.info/) or or [robo](https://robo.li/). (?)
+- Added Run several Moodle instances feature.
+
+## 1.0.0 - 2021-09-30
+
+- Support for Wiris MathType and Wiris Quizzes Moodle plugins suites.
+- Initial commit
+    - Commands to compile and build a customized Moodle instance using docker.
+    - Dependency management: download moodle-docker.
+    - Support for linux and OSx systems via bash commands.
+    - Document README.md
+        - Description
+        - User's guide
+        - FAQ
+        - Other information: legal, ...

--- a/README.md
+++ b/README.md
@@ -146,6 +146,27 @@ $ ./bin/wiris-moodle-docker-clean
 $ ./bin/wiris-moodle-docker-delete
 ```
 
+**01.1. Run several Moodle instances**
+
+By default, the script will load a single instance. If you want to run two
+or more different versions of Moodle at the same time, you have to add this
+environment variable prior running any of the steps at `Start` section:
+
+```bash
+# Define a project name; it will appear as a prefix on container names.
+export COMPOSE_PROJECT_NAME=moodle39
+
+# Use a different public web port from those already taken.
+export MOODLE_DOCKER_WEB_PORT=1234
+
+# Define a different VNC port for the new instance. 
+export MOODLE_DOCKER_SELENIUM_VNC_PORT=5901
+
+# [..] run all "02. `Start` steps" now
+```
+
+Repeat this process and the `Start` steps for each instance. If you want to run a new instance with a diferent Moodle or PHP version you must set a new configuration before running this steps.
+
 **02. Start**
 
 It configures and starts the docker containers that will serve the Moodle instances as defined on the install step.
@@ -184,10 +205,10 @@ $ ./bin/wiris-moodle-docker-test-init
 
 # Then, you'll be able to run phpunit and behat tests of any plugin:
 # Example: Run some behat tests by @tag.
-./moodle-docker/bin/moodle-docker-compose exec -u www-data webserver php admin/tool/behat/cli/run.php -vvv --colors --tags=@filter_wiris
+$ ./moodle-docker/bin/moodle-docker-compose exec -u www-data webserver php admin/tool/behat/cli/run.php -vvv --colors --tags=@filter_wiris
 
 # Example: Run a phpunit tests
-./moodle-docker/bin/moodle-docker-compose exec webserver vendor/bin/phpunit auth_manual_testcase auth/manual/tests/manual_test.php
+$ ./moodle-docker/bin/moodle-docker-compose exec webserver vendor/bin/phpunit auth_manual_testcase auth/manual/tests/manual_test.php
 
 ```
 
@@ -268,11 +289,9 @@ Check the Moodle's project at GitHub for [a full list of Moodle versions availab
 
 ### Can I run two different Moodle instances simultaneously with this tool?
 
-No.
+Yes.
 
-One Moodle Instance only can be run at the same time with this method.
-
-You will need to update the value of the `WIRIS_MOODLE_BRANCH` variable and run `stop` + `install` + `start` commands, every time in order to switch between Moodle instances.
+You will need to repeate the 01.1 and 2 sections for each instance of moodle that you want to run.
 
 ### What is the complete list of WIRIS MathType Moodle plugins?
 

--- a/bin/wiris-moodle-docker-start
+++ b/bin/wiris-moodle-docker-start
@@ -72,6 +72,13 @@ fi
 echo "=> Setting up Moodle Docker configuration..."
 cd moodle-docker
 cp config.docker-template.php ${MOODLE_DOCKER_WWWROOT}/config.php
+
+# Check if the container name is set
+if [ -n "${COMPOSE_PROJECT_NAME}" ]; then
+    # Add a command on the config template to add a prefix for the cookies on the Moodle instance
+    echo -e "\n\$CFG->sessioncookie = '${COMPOSE_PROJECT_NAME}';" >> ${MOODLE_DOCKER_WWWROOT}/config.php
+fi
+
 echo "=> Configuration is set."
 
 # Start up containers
@@ -93,6 +100,12 @@ echo "=> Upgrading Moodle..."
 bin/moodle-docker-compose  exec -T webserver php admin/cli/upgrade.php --non-interactive --allow-unstable
 echo "=> Moodle upgraded."
 
+DOCKER_PORT="8000"
+
+if [ -n "${MOODLE_DOCKER_WEB_PORT}" ]; then
+    DOCKER_PORT="${MOODLE_DOCKER_WEB_PORT}"
+fi
+
 echo "==============================================================================================="
-echo "=> Build is finished. Visit your ${WIRIS_MOODLE_BRANCH} (PHP_${MOODLE_DOCKER_PHP_VERSION}) Instance at http://localhost:8000/."
+echo "=> Build is finished. Visit your ${WIRIS_MOODLE_BRANCH} (PHP_${MOODLE_DOCKER_PHP_VERSION}) Instance at http://localhost:${DOCKER_PORT}/."
 echo "==============================================================================================="


### PR DESCRIPTION
## Description

Added `Run several Moodle instances` feature: Now the user have the possibility to run two or more instances of moodle with different Moodle and PHP versions.

This task adds a new section on readme that document the process to run multiple moodle instances. The `.bin/wiris-moodle-docker-start` file was changed:
- Added a prefix for the cookies name of the instance in order to use diferent cookies for each instance of moodle. 
- Changed logs to show the correct port used on each instance

Added a Change log file.

## Steps to reproduce

1. Open the terminal on the project.
2. Follow the steps from README:
2.1. Add advanced settings.
2.2. Install downloads all the necessary files and dependencies to your local computer (section 1 from readme).
2.3. Add the environment variable necessary to run a new instance of moodle (section 1.1 from readme).
2.4. Run the `wiris-moodle-docker-start` script to create the instance (section 2 from readme).
3. Repeat the second step with different versions of moodle and different container port for each instance desired.
4. Access to each instance of Moodle with the url `localhost:<selected-port>`.
5. Log as admin in each (credentials on FAQ from readme).
6. Navigate to `Site administrator > Server > Session handling` and check if `Cookie prefix` is the same as the provided in the step 2.3.