### PR TITLE
Added multiple instances feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this project is 1.0.0 released on 6th of September 2021.
 
-<!--
 ## [Unreleased]
--->
+
+- Added multiple instance feature (18578).
 
 ## 1.0.0 - 2021-09-30
 

--- a/bin/wiris-moodle-docker-restart
+++ b/bin/wiris-moodle-docker-restart
@@ -27,6 +27,11 @@ fi
 # (Moodle-docker) Set up path to Moodle code
 export MOODLE_DOCKER_WWWROOT=${WEB_DOCUMENTROOT}/${WIRIS_MOODLE_BRANCH}
 
+# Set up the prefix for containers based on current branch name when using multiple instances
+if [[ ${WIRIS_MOODLE_MULTIPLE} = "on" ]]; then
+    export COMPOSE_PROJECT_NAME=${WIRIS_MOODLE_BRANCH}
+fi
+
 # Step02. Shut down and destroy containers
 echo "=> Starting docker containers..."
 if [ ! -d "moodle-docker" ]; then

--- a/bin/wiris-moodle-docker-start
+++ b/bin/wiris-moodle-docker-start
@@ -55,6 +55,21 @@ fi
 echo "=> Setting up Database ${WIRIS_MOODLE_IMPORTED_DB}"
 cp ${WIRIS_MOODLE_IMPORTED_DB} /tmp/database.sql
 
+if [[ ${WIRIS_MOODLE_MULTIPLE} = "on" ]]; then
+    export COMPOSE_PROJECT_NAME=${WIRIS_MOODLE_BRANCH}
+
+    echo "=> Setting Multiple instance docker container: ${COMPOSE_PROJECT_NAME}"
+    # Get the version number of the moodle branch
+    MOODLE_VERSION=`echo ${WIRIS_MOODLE_BRANCH} | sed "s/MOODLE_//" | sed "s/_STABLE//"`
+    # Pad left tree 0 on the version number
+    MOODLE_VERSION=$(printf %04d $MOODLE_VERSION)
+    # Get the 5 digits MOODLE_DOCKER_WEB_PORT: 1 + MOODLE_VERSION 
+    export MOODLE_DOCKER_WEB_PORT="1`echo ${MOODLE_VERSION}`"
+    # Get the 5 digits MOODLE_DOCKER_SELENIUM_VNC_PORT: 2 + MOODLE_VERSION
+    export MOODLE_DOCKER_SELENIUM_VNC_PORT="2`echo ${MOODLE_VERSION}`"
+    echo "=> VNC Port for this instance ${MOODLE_DOCKER_SELENIUM_VNC_PORT}"
+fi
+
 # Step02. Validations on 'moodle' and 'moodle-docker'.
 
 # Check that the moodle-docker project is present.
@@ -70,8 +85,14 @@ fi
 
 # Ensure customized config.php for the Docker containers is in place
 echo "=> Setting up Moodle Docker configuration..."
-cd moodle-docker
+
 cp config.docker-template.php ${MOODLE_DOCKER_WWWROOT}/config.php
+# Change the cookies_prefix on the configuration file.
+sed -i "s/cookies_prefix/${WIRIS_MOODLE_BRANCH}/" ${MOODLE_DOCKER_WWWROOT}/config.php
+
+cd moodle-docker
+
+
 echo "=> Configuration is set."
 
 # Start up containers
@@ -93,6 +114,13 @@ echo "=> Upgrading Moodle..."
 bin/moodle-docker-compose  exec -T webserver php admin/cli/upgrade.php --non-interactive --allow-unstable
 echo "=> Moodle upgraded."
 
+# Set the default docker port
+DOCKER_PORT="8000"
+# Check If custom port is configured
+if [ -n "${MOODLE_DOCKER_WEB_PORT}" ]; then
+   DOCKER_PORT="${MOODLE_DOCKER_WEB_PORT}"
+fi
+
 echo "==============================================================================================="
-echo "=> Build is finished. Visit your ${WIRIS_MOODLE_BRANCH} (PHP_${MOODLE_DOCKER_PHP_VERSION}) Instance at http://localhost:8000/."
+echo "=> Build is finished. Visit your ${WIRIS_MOODLE_BRANCH} (PHP_${MOODLE_DOCKER_PHP_VERSION}) Instance at http://localhost:${DOCKER_PORT}/."
 echo "==============================================================================================="

--- a/bin/wiris-moodle-docker-stop
+++ b/bin/wiris-moodle-docker-stop
@@ -10,6 +10,10 @@
 echo "Setting up variables and parameters"
 export MOODLE_DOCKER_DB="mysql"
 
+if [[ ${WIRIS_MOODLE_MULTIPLE} = "on" ]]; then
+    export COMPOSE_PROJECT_NAME=${WIRIS_MOODLE_BRANCH}
+fi
+
 # (parameter) Path to store the Moodle code.
 if [ ! -d "$WEB_DOCUMENTROOT" ];
 then

--- a/bin/wiris-moodle-docker-test
+++ b/bin/wiris-moodle-docker-test
@@ -32,6 +32,11 @@ if [ ! -d "moodle-docker" ]; then
     exit 1
 fi
 
+# Set up the prefix for containers based on current branch name when using multiple instances
+if [[ ${WIRIS_MOODLE_MULTIPLE} = "on" ]]; then
+    export COMPOSE_PROJECT_NAME=${WIRIS_MOODLE_BRANCH}
+fi
+
 # Step02. Initialize behat environment
 echo "=> 2/4: Starting behat environment..."
 

--- a/bin/wiris-moodle-docker-test-behat
+++ b/bin/wiris-moodle-docker-test-behat
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Script: Moodle--BehatTestsRun
+# Description: Run behat tests by @tag.
+# Params:
+# - Moodle branch version
+# - Tag
+
+echo "Setting up variables and parameters"
+
+# Get the tag parameter
+while [[ $# -gt 0 ]]; do
+    case $1 in -t|--tag)
+        tag=${2}
+        shift # past argument
+        shift # past value
+        ;;
+    esac
+done
+
+# Set up the prefix for containers based on current branch name when using multiple instances
+if [[ ${WIRIS_MOODLE_MULTIPLE} = "on" ]]; then
+    export COMPOSE_PROJECT_NAME=${WIRIS_MOODLE_BRANCH}
+    echo "=> Testing on docker container: ${COMPOSE_PROJECT_NAME}"
+fi
+
+echo "=> 1/1: Starting behat ${tag} tests..."
+# Run behat tests
+./moodle-docker/bin/moodle-docker-compose exec -u www-data webserver php admin/tool/behat/cli/run.php -vvv --colors --tags=@$tag

--- a/bin/wiris-moodle-docker-test-init
+++ b/bin/wiris-moodle-docker-test-init
@@ -32,6 +32,11 @@ if [ ! -d "moodle-docker" ]; then
     exit 1
 fi
 
+# Set up the prefix for containers based on current branch name when using multiple instances
+if [[ ${WIRIS_MOODLE_MULTIPLE} = "on" ]]; then
+    export COMPOSE_PROJECT_NAME=${WIRIS_MOODLE_BRANCH}
+fi
+
 # Step02. Initialize behat environment
 echo "=> 2/3: Starting behat environment..."
 

--- a/bin/wiris-moodle-docker-test-phpunit
+++ b/bin/wiris-moodle-docker-test-phpunit
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Script: Moodle--PHPUnitTestsRun
+# Description: Run a phpunit test.
+# Params:
+# - Moodle branch version
+# - Tag
+
+echo "Setting up variables and parameters"
+
+# Get the tag parameter
+while [[ $# -gt 0 ]]; do
+    case $1 in -t|--test)
+        test=${2}
+        shift # past argument
+        shift # past value
+        ;;
+    esac
+done
+
+# Set up the prefix for containers based on current branch name when using multiple instances
+if [ ${WIRIS_MOODLE_MULTIPLE} = "on" ]; then
+    export COMPOSE_PROJECT_NAME=${WIRIS_MOODLE_BRANCH}
+    echo "=> Testing on docker container: ${COMPOSE_PROJECT_NAME}"
+fi
+
+echo "=> 1/1: Starting phpunit ${test} test..."
+# Run behat tests
+./moodle-docker/bin/moodle-docker-compose exec webserver vendor/bin/phpunit auth_manual_testcase auth/manual/tests/$test

--- a/config.docker-template.php
+++ b/config.docker-template.php
@@ -1,0 +1,101 @@
+<?php  // Moodle configuration file
+
+unset($CFG);
+global $CFG;
+$CFG = new stdClass();
+
+$CFG->dbtype    = getenv('MOODLE_DOCKER_DBTYPE');
+$CFG->dblibrary = 'native';
+$CFG->dbhost    = 'db';
+$CFG->dbname    = getenv('MOODLE_DOCKER_DBNAME');
+$CFG->dbuser    = getenv('MOODLE_DOCKER_DBUSER');
+$CFG->dbpass    = getenv('MOODLE_DOCKER_DBPASS');
+$CFG->prefix    = 'm_';
+$CFG->dboptions = ['dbcollation' => getenv('MOODLE_DOCKER_DBCOLLATION')];
+
+$host = 'localhost';
+if (!empty(getenv('MOODLE_DOCKER_WEB_HOST'))) {
+    $host = getenv('MOODLE_DOCKER_WEB_HOST');
+}
+$CFG->wwwroot   = "http://{$host}";
+$port = getenv('MOODLE_DOCKER_WEB_PORT');
+if (!empty($port)) {
+    // Extract port in case the format is bind_ip:port.
+    $parts = explode(':', $port);
+    $port = end($parts);
+    if ((string)(int)$port === (string)$port) { // Only if it's int value.
+        $CFG->wwwroot .= ":{$port}";
+    }
+}
+$CFG->dataroot  = '/var/www/moodledata';
+$CFG->admin     = 'admin';
+$CFG->directorypermissions = 0777;
+$CFG->smtphosts = 'mailhog:1025';
+$CFG->noreplyaddress = 'noreply@example.com';
+
+// Debug options - possible to be controlled by flag in future..
+$CFG->debug = (E_ALL | E_STRICT); // DEBUG_DEVELOPER
+$CFG->debugdisplay = 1;
+$CFG->debugstringids = 1; // Add strings=1 to url to get string ids.
+$CFG->perfdebug = 15;
+$CFG->debugpageinfo = 1;
+$CFG->allowthemechangeonurl = 1;
+$CFG->passwordpolicy = 0;
+$CFG->cronclionly = 0;
+$CFG->pathtophp = '/usr/local/bin/php';
+
+$CFG->phpunit_dataroot  = '/var/www/phpunitdata';
+$CFG->phpunit_prefix = 't_';
+define('TEST_EXTERNAL_FILES_HTTP_URL', 'http://exttests:9000');
+
+$CFG->behat_wwwroot   = 'http://webserver';
+$CFG->behat_dataroot  = '/var/www/behatdata';
+$CFG->behat_prefix = 'b_';
+$CFG->behat_profiles = array(
+    'default' => array(
+        'browser' => getenv('MOODLE_DOCKER_BROWSER'),
+        'wd_host' => 'http://selenium:4444/wd/hub',
+    ),
+);
+$CFG->behat_faildump_path = '/var/www/behatfaildumps';
+
+$CFG->sessioncookie = 'cookies_prefix';
+
+define('PHPUNIT_LONGTEST', true);
+
+if (getenv('MOODLE_DOCKER_APP')) {
+    $appport = getenv('MOODLE_DOCKER_APP_PORT') ?: 8100;
+
+    $CFG->behat_ionic_wwwroot = "http://moodleapp:$appport";
+}
+
+if (getenv('MOODLE_DOCKER_PHPUNIT_EXTRAS')) {
+    define('TEST_SEARCH_SOLR_HOSTNAME', 'solr');
+    define('TEST_SEARCH_SOLR_INDEXNAME', 'test');
+    define('TEST_SEARCH_SOLR_PORT', 8983);
+
+    define('TEST_SESSION_REDIS_HOST', 'redis');
+    define('TEST_CACHESTORE_REDIS_TESTSERVERS', 'redis');
+
+    define('TEST_CACHESTORE_MONGODB_TESTSERVER', 'mongodb://mongo:27017');
+
+    define('TEST_CACHESTORE_MEMCACHED_TESTSERVERS', "memcached0:11211\nmemcached1:11211");
+    define('TEST_CACHESTORE_MEMCACHE_TESTSERVERS', "memcached0:11211\nmemcached1:11211");
+
+    define('TEST_LDAPLIB_HOST_URL', 'ldap://ldap');
+    define('TEST_LDAPLIB_BIND_DN', 'cn=admin,dc=openstack,dc=org');
+    define('TEST_LDAPLIB_BIND_PW', 'password');
+    define('TEST_LDAPLIB_DOMAIN', 'ou=Users,dc=openstack,dc=org');
+
+    define('TEST_AUTH_LDAP_HOST_URL', 'ldap://ldap');
+    define('TEST_AUTH_LDAP_BIND_DN', 'cn=admin,dc=openstack,dc=org');
+    define('TEST_AUTH_LDAP_BIND_PW', 'password');
+    define('TEST_AUTH_LDAP_DOMAIN', 'ou=Users,dc=openstack,dc=org');
+
+    define('TEST_ENROL_LDAP_HOST_URL', 'ldap://ldap');
+    define('TEST_ENROL_LDAP_BIND_DN', 'cn=admin,dc=openstack,dc=org');
+    define('TEST_ENROL_LDAP_BIND_PW', 'password');
+    define('TEST_ENROL_LDAP_DOMAIN', 'ou=Users,dc=openstack,dc=org');
+}
+
+require_once(__DIR__ . '/lib/setup.php');


### PR DESCRIPTION
## Description

Added `Run several Moodle instances` feature: Now the user have the possibility to run two or more instances of moodle with different Moodle and PHP versions.

This task adds a new section on readme that document the process to run multiple moodle instances. The `.bin/wiris-moodle-docker-start` file was changed:

Added a prefix for the cookies name of the instance in order to use diferent cookies for each instance of moodle.
Changed logs to show the correct port used on each instance
Added a Change log file.

## Steps to reproduce
1. Open the terminal on the project.
2. Follow the steps from README:
2.1. Add advanced settings.
2.2. Install downloads all the necessary files and dependencies to your local computer (section 1 from readme).
2.3. Add the environment variable necessary to run a new instance of moodle (section 1.1 from readme).
2.4. Run the `wiris-moodle-docker-start` script to create the instance (section 2 from readme).
3. Repeat the second step with different versions of moodle and different container ports for each instance desired.
4. Access to each instance of Moodle with the url `localhost:<selected-port>`.
5. Log as admin in each (credentials on FAQ from readme).
6. Navigate to `Site administrator > Server > Session handling` and check if `Cookie prefix` is the same as the provided in the step 2.3.