### PR TITLE
Update moodle-docker when using install script

### DIFF
--- a/bin/wiris-moodle-docker-install
+++ b/bin/wiris-moodle-docker-install
@@ -90,9 +90,22 @@ WIRIS_MOODLE_MATHTYPE_PLUGINS=(
 
 # Step02. Setup and run 'moodle-docker'.
 echo "=> 2/5: Downloading Moodle Docker containers"
-# Clone Official Moodle-docker repository
-if [ ! -d "moodle-docker" ]; then
-    # Control will enter here if $DIRECTORY doesn't exists.
+
+if [ -d "moodle-docker" ]; then
+    # Control will enter here if moodle-docker directory exists.
+    cd moodle-docker
+    if [ -d ".git" ]; then
+        echo "=> Pulling Moodle-docker code..."
+        git pull
+        echo "=> Pulled code."
+    else
+        echo "=> Cloning Moodle-docker..."
+        git clone ${MOODLE_DOCKER_SOURCE} 
+        echo "=> Cloned Moodle-docker to ./moodle-docker."
+    fi
+    cd ..
+else
+    # Control will enter here if moodle-docker directory doesn't exists.
     echo "=> Cloning Moodle-docker..."
     git clone ${MOODLE_DOCKER_SOURCE} 
     echo "=> Cloned Moodle-docker to ./moodle-docker."
@@ -104,18 +117,18 @@ echo "=> 3/5: Downloading Moodle ${WIRIS_MOODLE_BRANCH} to ${MOODLE_DOCKER_WWWRO
 # Clone Official Moodle repository
 cd ${WEB_DOCUMENTROOT}
 if [ -d "${WIRIS_MOODLE_BRANCH}" ]; then
-  # Control will enter here if $DIRECTORY exists.
-  cd ${WIRIS_MOODLE_BRANCH}
-  if [ -d ".git" ]; then
-    echo "=> Pulling Moodle code..."
-    git checkout ${WIRIS_MOODLE_BRANCH} 
-    git pull
-    echo "=> Pulled code from ${WIRIS_MOODLE_BRANCH} to ${MOODLE_DOCKER_WWWROOT}/."
-  else
-    echo "=> Cloning Moodle code..."
-    git clone -b ${WIRIS_MOODLE_BRANCH} https://github.com/moodle/moodle.git ${WIRIS_MOODLE_BRANCH}
-    echo "=> Cloned code from ${WIRIS_MOODLE_BRANCH} to ${MOODLE_DOCKER_WWWROOT}/."
-  fi
+    # Control will enter here if $DIRECTORY exists.
+    cd ${WIRIS_MOODLE_BRANCH}
+    if [ -d ".git" ]; then
+        echo "=> Pulling Moodle code..."
+        git checkout ${WIRIS_MOODLE_BRANCH} 
+        git pull
+        echo "=> Pulled code from ${WIRIS_MOODLE_BRANCH} to ${MOODLE_DOCKER_WWWROOT}/."
+    else
+        echo "=> Cloning Moodle code..."
+        git clone -b ${WIRIS_MOODLE_BRANCH} https://github.com/moodle/moodle.git ${WIRIS_MOODLE_BRANCH}
+        echo "=> Cloned code from ${WIRIS_MOODLE_BRANCH} to ${MOODLE_DOCKER_WWWROOT}/."
+    fi
 else
     echo "=> Cloning Moodle code from scratch..."
     git clone -b ${WIRIS_MOODLE_BRANCH} https://github.com/moodle/moodle.git ${WIRIS_MOODLE_BRANCH}

--- a/bin/wiris-moodle-docker-start
+++ b/bin/wiris-moodle-docker-start
@@ -118,7 +118,7 @@ echo "=> Moodle upgraded."
 DOCKER_PORT="8000"
 # Check If custom port is configured
 if [ -n "${MOODLE_DOCKER_WEB_PORT}" ]; then
-   DOCKER_PORT="${MOODLE_DOCKER_WEB_PORT}"
+    DOCKER_PORT="${MOODLE_DOCKER_WEB_PORT}"
 fi
 
 echo "==============================================================================================="

--- a/bin/wiris-moodle-docker-test-phpunit
+++ b/bin/wiris-moodle-docker-test-phpunit
@@ -19,7 +19,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Set up the prefix for containers based on current branch name when using multiple instances
-if [ ${WIRIS_MOODLE_MULTIPLE} = "on" ]; then
+if [[ ${WIRIS_MOODLE_MULTIPLE} = "on" ]]; then
     export COMPOSE_PROJECT_NAME=${WIRIS_MOODLE_BRANCH}
     echo "=> Testing on docker container: ${COMPOSE_PROJECT_NAME}"
 fi


### PR DESCRIPTION
## Description
Updated the script `wiris-moodle-docker-install` to update the `moodle-docker` project if is already installed.

Also added missing brackets on `bin/wiris-moodle-docker-test-phpunit` in order to follow the same convention between scripts.

## Steps to reproduce

1. Open the terminal on the project.
2. Set environment variable WIRIS_MOODLE_BRANCH.
3. Use the install script with `$ ./bin/wiris-moodle-docker-install`.
4. Check if moodel-docker is download on moodle-docker folder.
5. Use again the install script with `$ ./bin/wiris-moodle-docker-install`.

As moodle-docker is already installed the script will do a pull updating the folder.

